### PR TITLE
ci: Correct the tag of the dotenv-linter/action-dotenv-linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: dotenv-linter/action-dotenv-linter@9c9a09ba60235ae0b92b2e2ed8f4268ac76d075f # 2.23.0
+      - uses: dotenv-linter/action-dotenv-linter@9c9a09ba60235ae0b92b2e2ed8f4268ac76d075f # v2.23.0
         with:
           dotenv_linter_flags: --skip UnorderedKey
           fail_on_error: true


### PR DESCRIPTION
Renovate needs the correct tag comment for lookup.

--- commit logs ---
* fix(ci): Correct the tag of the dotenv-linter/action-dotenv-linter
