### PR TITLE
style: rename ListClientData to GetAllClientData

### DIFF
--- a/internal/adapter/repository/ent/clientdata.go
+++ b/internal/adapter/repository/ent/clientdata.go
@@ -9,7 +9,7 @@ import (
 
 type ClientDataRepository interface {
 	CreateClientData(cxt context.Context, username string, apiKey string) (*ent.ClientData, error)
-	ListClientData(cxt context.Context, limit int32) ([]*ent.ClientData, error)
+	GetAllClientData(cxt context.Context, limit int32) ([]*ent.ClientData, error)
 	DeleteClientData(ctx context.Context, client_id pulid.ID) (*pulid.ID, error)
 }
 
@@ -34,7 +34,7 @@ func (r *clientDataRepositoryImpl) CreateClientData(ctx context.Context, usernam
 	return clientData, nil
 }
 
-func (r *clientDataRepositoryImpl) ListClientData(ctx context.Context, limit int32) ([]*ent.ClientData, error) {
+func (r *clientDataRepositoryImpl) GetAllClientData(ctx context.Context, limit int32) ([]*ent.ClientData, error) {
 	clientDataList, err := r.DB.ClientData.Query().
 		Limit(int(limit)).
 		All(ctx)

--- a/internal/usecase/clientdata_usecase.go
+++ b/internal/usecase/clientdata_usecase.go
@@ -36,7 +36,7 @@ func (u *clientDataUsecaseImpl) CreateClientData(ctx context.Context, username s
 }
 
 func (u *clientDataUsecaseImpl) ListClientData(ctx context.Context, limit int32) ([]*domain.ClientData, error) {
-	dataList, err := u.clientDataRepository.ListClientData(ctx, limit)
+	dataList, err := u.clientDataRepository.GetAllClientData(ctx, limit)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This pull request includes several changes to the `clientdata.go` and `clientdata_usecase.go` files to rename the `ListClientData` method to `GetAllClientData`. This change affects both the repository interface and its implementation, as well as the use case layer.

Changes to method names:

* [`internal/adapter/repository/ent/clientdata.go`](diffhunk://#diff-b2aaec55320e47bbad53373c13b9a31779b6b11ccd290ffedc4f5aa90f4f8668L12-R12): Renamed the `ListClientData` method to `GetAllClientData` in the `ClientDataRepository` interface.
* [`internal/adapter/repository/ent/clientdata.go`](diffhunk://#diff-b2aaec55320e47bbad53373c13b9a31779b6b11ccd290ffedc4f5aa90f4f8668L37-R37): Updated the implementation of the `clientDataRepositoryImpl` to reflect the method name change from `ListClientData` to `GetAllClientData`.
* [`internal/usecase/clientdata_usecase.go`](diffhunk://#diff-1e2c0226e1d5a8c090368e1c676c984afe0b088f0280c8bbde15915d29350ac0L39-R39): Updated the use case method to call `GetAllClientData` instead of `ListClientData`.

--- commit logs ---
* style: rename ListClientData to GetAllClientData
